### PR TITLE
Add basic automated tests

### DIFF
--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/HomeRouteTest.php
+++ b/tests/Feature/HomeRouteTest.php
@@ -1,0 +1,16 @@
+<?php
+
+test('home page renders', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(200);
+    $response->assertSee('Get Started');
+});
+
+test('welcome page renders', function () {
+    $response = $this->get('/welcome');
+
+    $response->assertStatus(200);
+    $response->assertSee('Laravel');
+});
+

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,10 +11,7 @@
 |
 */
 
-/*uses(
-    Tests\TestCase::class,
-    Illuminate\Foundation\Testing\RefreshDatabase::class,
-)->in('Feature');*/
+uses(Tests\TestCase::class)->in('Feature');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}

--- a/tests/Unit/UserModelTest.php
+++ b/tests/Unit/UserModelTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Models\User;
+
+test('getRoles returns available roles', function () {
+    expect(User::getRoles())->toBe([
+        'admin' => 'Amministratore',
+        'user' => 'Utente',
+    ]);
+});
+
+test('getStatuses returns available statuses', function () {
+    expect(User::getStatuses())->toBe([
+        1 => 'Attivo',
+        0 => 'Disattivo',
+    ]);
+});
+


### PR DESCRIPTION
## Summary
- enable Pest test case usage
- add base TestCase and CreatesApplication
- add feature tests for home and welcome routes
- add unit tests for User model role and status helpers

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684818f09aa88323a782d7901a7471ce